### PR TITLE
Made the asterisk* now match the dash- in the name filter

### DIFF
--- a/dotnet/OutlinerFilter.cs
+++ b/dotnet/OutlinerFilter.cs
@@ -44,8 +44,8 @@ namespace Outliner
                     // Escape the filter value.
                     _nameFilter = "^" + Regex.Escape(value);
                     
-                    // Replace all escaped occurrences of * with [\w\s]*.
-                    _nameFilter = Regex.Replace(_nameFilter, @"(\\\*)", @"[\w\s]*");
+                    // Replace all escaped occurrences of * with [\w\s-]*.
+                    _nameFilter = Regex.Replace(_nameFilter, @"(\\\*)", @"[\w\s-]*");
                 }
             }
         }


### PR DESCRIPTION
Names that have dashes in them like name-with-dash are not matched in the outliner filter.
To match that name, you'd have to enter *-*-*
I explicitly added a match to the dash in my fork.

However in 3dsMax 2012x64 I was able to make an object with the name:
!@#$%^&*()_ -+=<>,.??:;"'{[}]|®
so it may be worth rethinking the entire regex.
